### PR TITLE
¬ User error

### DIFF
--- a/scripts/03-install_tomcat.sh
+++ b/scripts/03-install_tomcat.sh
@@ -3,9 +3,9 @@
 set -e
 
 # Variables
-TOMCAT_USER=ubuntu
-TOMCAT_GROUP=ubuntu
-TOMCAT_HOME=/home/ubuntu/tomcat
+TOMCAT_USER=$(whoami)
+TOMCAT_GROUP=$(id -gn)
+TOMCAT_HOME=/home/$TOMCAT_USER/tomcat
 
 # Function to fetch the latest Tomcat version
 fetch_latest_version() {


### PR DESCRIPTION
The old script had a problem if the Ubuntu user hadn't been created. To fully automate it, the best option was to:
1. Create the user
2. Use the current user The best option is to use the current user because if you create the user, you'll have permission issues with folders during installation.